### PR TITLE
Added Filter by Location Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A CLI tool for job seekers to track tech internships and new-grad positions. Dat
 
 - Track both internships and new-grad positions
 - Filter job postings by time (last day, week, or month)
+- Filter job postings by locations
 - View company name, job title, location, and application link
 - Real-time data from GitHub repositories
 - Easy-to-use command-line interface
@@ -34,12 +35,19 @@ swelist --role newgrad
 
 # Show internship positions from last week
 swelist --role internship --timeframe lastweek
+
+# Show internship positions for Toronto
+swelist --role internship --location Toronto
+
+# Show new-grad positions for last month for Boston and New York
+swelist --role newgrad --timeframe lastmonth --location "Boston, New York"
 ```
 
 ### Options
 
 - `--role`: Choose between `internship` (default) or `newgrad` positions
 - `--timeframe`: Filter postings by time period: `lastday` (default), `lastweek`, or `lastmonth`
+-  `--location`: Filter locations by giving single location: `Canada` or multiple locations `"CA, Boston, Toronto, NY"`
 
 ## Example Output
 

--- a/swelist/main.py
+++ b/swelist/main.py
@@ -76,7 +76,7 @@ def filter_by_location(postings, location):
         for user_loc in user_locations:
             for loc_norm in job_locations:
                 if len(user_loc) == 2:  # treat as state code
-                    if loc_norm.endswith(", " + user_loc):
+                    if loc_norm.endswith(user_loc):
                         filtered.append(job)
                         break  # no need to check other job locations
                 else:  # city or country


### PR DESCRIPTION
### Summary
This PR enhances the job filtering functionality by allowing users to filter postings based on one or multiple preferred locations. Users can now provide a comma-separated list of locations (city, state code, or country), and the CLI will return all job postings that match any of the specified locations.

### Details
- **Multiple locations support:** Users can input multiple locations separated by commas (e.g., "NY, CA, Toronto"), and the filter will match postings in any of them.
- **City, state, and country matching:**
  - State codes (e.g., CA, NY) are matched at the end of the location string.
  - City or country names are matched case-insensitively if they appear anywhere in the job’s location.
- **Backward compatibility:** If location is "all" (default), no filtering is applied.
- **Efficient filtering:** Filtering is applied after timeframe filtering to reduce the number of items processed.

### Example
`swelist --role internship --timeframe lastweek --location "NY, CA, Remote"
`