### PR TITLE
Add jobgpt: AI writing assistant for job applications

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,11 @@ setup(
     include_package_data=True,
     install_requires=[
         "typer",
+        "rich",
     ],
+    extras_require={
+        "ai": ["openai>=1.0.0"],
+    },
     entry_points={
         "console_scripts": [
             "swelist=swelist.main:app",

--- a/swelist/jobgpt.py
+++ b/swelist/jobgpt.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
-from typing import Optional
-from typing_extensions import Annotated
+from typing import Annotated, Optional
 
 import typer
 from rich import print

--- a/swelist/jobgpt.py
+++ b/swelist/jobgpt.py
@@ -1,0 +1,142 @@
+import os
+import subprocess
+from typing import Optional
+from typing_extensions import Annotated
+
+import typer
+from rich import print
+from rich.markdown import Markdown
+from rich.panel import Panel
+
+jobgpt_app = typer.Typer(
+    name="jobgpt",
+    help="AI writing assistant for job applications.",
+    no_args_is_help=True,
+)
+
+_SYSTEM_PROMPTS = {
+    "why_company": (
+        "You are an expert career coach helping candidates craft compelling, authentic answers "
+        "to the 'Why do you want to work at [Company]?' interview question. "
+        "Write in first person. Be specific, enthusiastic, and concise (2-3 paragraphs). "
+        "Ground the answer in the candidate's actual background."
+    ),
+    "behavioral": (
+        "You are an expert career coach helping candidates answer behavioral interview questions "
+        "using the STAR method (Situation, Task, Action, Result). "
+        "Write in first person. Be concrete and quantify results where possible. "
+        "Keep the answer under 400 words."
+    ),
+    "general": (
+        "You are an expert career coach and job application strategist. "
+        "Provide clear, actionable, and tailored advice."
+    ),
+}
+
+_USER_TEMPLATES = {
+    "why_company": (
+        "Company: {company}\n\n"
+        "My background: {background}\n\n"
+        "Write a compelling answer to 'Why do you want to work at {company}?' "
+        "that connects my background to what this company is known for."
+    ),
+    "behavioral": (
+        "Behavioral question: {question}\n\n"
+        "{resume_section}"
+        "Write a strong STAR-method answer for this question."
+    ),
+    "general": "{prompt}",
+}
+
+
+def _call_openai(system: str, user: str, model: str) -> str:
+    try:
+        from openai import OpenAI
+    except ImportError:
+        print(
+            "[bold red]Error:[/bold red] openai package not installed. "
+            "Run: [cyan]pip install 'swelist[ai]'[/cyan]"
+        )
+        raise typer.Exit(1)
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print(
+            "[bold red]Error:[/bold red] OPENAI_API_KEY environment variable not set.\n"
+            "Export it with: [cyan]export OPENAI_API_KEY=sk-...[/cyan]"
+        )
+        raise typer.Exit(1)
+
+    client = OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        max_tokens=600,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def _render(title: str, content: str, copy: bool) -> None:
+    print(Panel(Markdown(content), title=f"[bold]{title}[/bold]", border_style="cyan"))
+    if copy:
+        try:
+            proc = subprocess.run(
+                ["xclip", "-selection", "clipboard"],
+                input=content.encode(),
+                check=False,
+            )
+            if proc.returncode != 0:
+                subprocess.run(["pbcopy"], input=content.encode(), check=True)
+            print("[dim]Copied to clipboard.[/dim]")
+        except Exception:
+            print("[dim yellow]Could not copy to clipboard (install xclip or pbcopy).[/dim yellow]")
+
+
+@jobgpt_app.command("why-company")
+def why_company(
+    company: Annotated[str, typer.Argument(help="Company name")],
+    background: Annotated[str, typer.Option(help="Your background summary")] = "",
+    model: Annotated[str, typer.Option(help="OpenAI model")] = "gpt-4o",
+    copy: Annotated[bool, typer.Option("--copy", help="Copy output to clipboard")] = False,
+):
+    """Generate a 'Why this company?' answer for interviews."""
+    user = _USER_TEMPLATES["why_company"].format(company=company, background=background)
+    result = _call_openai(_SYSTEM_PROMPTS["why_company"], user, model)
+    _render(f"Why {company}?", result, copy)
+
+
+@jobgpt_app.command("behavioral")
+def behavioral(
+    question: Annotated[str, typer.Argument(help="Behavioral interview question")],
+    resume: Annotated[Optional[str], typer.Option(help="Path to resume text file")] = None,
+    model: Annotated[str, typer.Option(help="OpenAI model")] = "gpt-4o",
+    copy: Annotated[bool, typer.Option("--copy", help="Copy output to clipboard")] = False,
+):
+    """Generate a STAR-format answer to a behavioral interview question."""
+    resume_section = ""
+    if resume:
+        try:
+            with open(resume) as f:
+                resume_section = f"Resume context:\n{f.read()}\n\n"
+        except OSError as e:
+            typer.echo(f"Could not read resume file: {e}", err=True)
+            raise typer.Exit(1)
+
+    user = _USER_TEMPLATES["behavioral"].format(question=question, resume_section=resume_section)
+    result = _call_openai(_SYSTEM_PROMPTS["behavioral"], user, model)
+    _render("Behavioral Answer (STAR)", result, copy)
+
+
+@jobgpt_app.command("ask")
+def ask(
+    question: Annotated[str, typer.Argument(help="Any job-search or career question")],
+    model: Annotated[str, typer.Option(help="OpenAI model")] = "gpt-4o",
+    copy: Annotated[bool, typer.Option("--copy", help="Copy output to clipboard")] = False,
+):
+    """Ask any career or job-search question."""
+    user = _USER_TEMPLATES["general"].format(prompt=question)
+    result = _call_openai(_SYSTEM_PROMPTS["general"], user, model)
+    _render("Career Advice", result, copy)

--- a/swelist/main.py
+++ b/swelist/main.py
@@ -21,6 +21,9 @@ class TimeFilter(str, Enum):
 
 app = typer.Typer()
 
+from swelist.jobgpt import jobgpt_app
+app.add_typer(jobgpt_app, name="jobgpt")
+
 __version__ = "0.1.7"
 
 # @app.command()

--- a/tests/test_jobgpt.py
+++ b/tests/test_jobgpt.py
@@ -1,84 +1,65 @@
 import pytest
 from typer.testing import CliRunner
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 from swelist.main import app
 
 runner = CliRunner()
 
-
-def _make_openai_mock(reply="Mocked AI response."):
-    mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content=reply))]
-    )
-    mock_ctor = MagicMock(return_value=mock_client)
-    return mock_ctor, mock_client
+MOCK_REPLY = "Mocked AI response."
 
 
-def test_why_company_basic(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    mock_ctor, client = _make_openai_mock()
-    with patch("openai.OpenAI", mock_ctor):
+def test_why_company_basic():
+    with patch("swelist.jobgpt._call_openai", return_value=MOCK_REPLY) as mock_call:
         result = runner.invoke(app, ["jobgpt", "why-company", "Stripe"])
     assert result.exit_code == 0, result.output
-    assert "Mocked AI response." in result.output
+    assert MOCK_REPLY in result.output
 
 
-def test_why_company_with_background(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    mock_ctor, client = _make_openai_mock()
-    with patch("openai.OpenAI", mock_ctor):
+def test_why_company_with_background():
+    with patch("swelist.jobgpt._call_openai", return_value=MOCK_REPLY) as mock_call:
         result = runner.invoke(app, ["jobgpt", "why-company", "Stripe", "--background", "5yr data eng"])
     assert result.exit_code == 0, result.output
-    call_args = client.chat.completions.create.call_args
-    user_msg = call_args.kwargs["messages"][1]["content"]
-    assert "5yr data eng" in user_msg
+    _, user, _ = mock_call.call_args.args
+    assert "5yr data eng" in user
 
 
-def test_behavioral_basic(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    mock_ctor, _ = _make_openai_mock()
-    with patch("openai.OpenAI", mock_ctor):
+def test_behavioral_basic():
+    with patch("swelist.jobgpt._call_openai", return_value=MOCK_REPLY):
         result = runner.invoke(app, ["jobgpt", "behavioral", "Tell me about a conflict"])
     assert result.exit_code == 0, result.output
-    assert "Mocked AI response." in result.output
+    assert MOCK_REPLY in result.output
 
 
-def test_behavioral_with_resume(monkeypatch, tmp_path):
+def test_behavioral_with_resume(tmp_path):
     resume = tmp_path / "resume.txt"
     resume.write_text("Senior engineer at AWS for 5 years.")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    mock_ctor, client = _make_openai_mock()
-    with patch("openai.OpenAI", mock_ctor):
+    with patch("swelist.jobgpt._call_openai", return_value=MOCK_REPLY) as mock_call:
         result = runner.invoke(
             app,
             ["jobgpt", "behavioral", "Tell me about a time you led a project", "--resume", str(resume)],
         )
     assert result.exit_code == 0, result.output
-    call_args = client.chat.completions.create.call_args
-    user_msg = call_args.kwargs["messages"][1]["content"]
-    assert "Senior engineer at AWS" in user_msg
+    _, user, _ = mock_call.call_args.args
+    assert "Senior engineer at AWS" in user
 
 
-def test_behavioral_missing_resume(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    result = runner.invoke(app, ["jobgpt", "behavioral", "Question", "--resume", "/nonexistent/resume.txt"])
+def test_behavioral_missing_resume():
+    with patch("swelist.jobgpt._call_openai", return_value=MOCK_REPLY):
+        result = runner.invoke(app, ["jobgpt", "behavioral", "Question", "--resume", "/nonexistent/resume.txt"])
     assert result.exit_code != 0
 
 
-def test_ask_basic(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    mock_ctor, _ = _make_openai_mock()
-    with patch("openai.OpenAI", mock_ctor):
+def test_ask_basic():
+    with patch("swelist.jobgpt._call_openai", return_value=MOCK_REPLY):
         result = runner.invoke(app, ["jobgpt", "ask", "What salary should I negotiate?"])
     assert result.exit_code == 0, result.output
-    assert "Mocked AI response." in result.output
+    assert MOCK_REPLY in result.output
 
 
 def test_missing_api_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    mock_ctor, _ = _make_openai_mock()
-    with patch("openai.OpenAI", mock_ctor):
+    import sys
+    with patch.dict(sys.modules, {"openai": MagicMock()}):
         result = runner.invoke(app, ["jobgpt", "ask", "Question"])
     assert result.exit_code != 0
 
@@ -91,11 +72,8 @@ def test_missing_openai_package(monkeypatch):
     assert result.exit_code != 0
 
 
-def test_system_prompt_used(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    mock_ctor, client = _make_openai_mock()
-    with patch("openai.OpenAI", mock_ctor):
+def test_system_prompt_used():
+    with patch("swelist.jobgpt._call_openai", return_value=MOCK_REPLY) as mock_call:
         runner.invoke(app, ["jobgpt", "why-company", "Google"])
-    call_args = client.chat.completions.create.call_args
-    system_msg = call_args.kwargs["messages"][0]["content"]
-    assert "career coach" in system_msg.lower()
+    system, _, _ = mock_call.call_args.args
+    assert "career coach" in system.lower()

--- a/tests/test_jobgpt.py
+++ b/tests/test_jobgpt.py
@@ -1,0 +1,101 @@
+import pytest
+from typer.testing import CliRunner
+from unittest.mock import MagicMock, patch
+from swelist.main import app
+
+runner = CliRunner()
+
+
+def _make_openai_mock(reply="Mocked AI response."):
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content=reply))]
+    )
+    mock_ctor = MagicMock(return_value=mock_client)
+    return mock_ctor, mock_client
+
+
+def test_why_company_basic(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_ctor, client = _make_openai_mock()
+    with patch("openai.OpenAI", mock_ctor):
+        result = runner.invoke(app, ["jobgpt", "why-company", "Stripe"])
+    assert result.exit_code == 0, result.output
+    assert "Mocked AI response." in result.output
+
+
+def test_why_company_with_background(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_ctor, client = _make_openai_mock()
+    with patch("openai.OpenAI", mock_ctor):
+        result = runner.invoke(app, ["jobgpt", "why-company", "Stripe", "--background", "5yr data eng"])
+    assert result.exit_code == 0, result.output
+    call_args = client.chat.completions.create.call_args
+    user_msg = call_args.kwargs["messages"][1]["content"]
+    assert "5yr data eng" in user_msg
+
+
+def test_behavioral_basic(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_ctor, _ = _make_openai_mock()
+    with patch("openai.OpenAI", mock_ctor):
+        result = runner.invoke(app, ["jobgpt", "behavioral", "Tell me about a conflict"])
+    assert result.exit_code == 0, result.output
+    assert "Mocked AI response." in result.output
+
+
+def test_behavioral_with_resume(monkeypatch, tmp_path):
+    resume = tmp_path / "resume.txt"
+    resume.write_text("Senior engineer at AWS for 5 years.")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_ctor, client = _make_openai_mock()
+    with patch("openai.OpenAI", mock_ctor):
+        result = runner.invoke(
+            app,
+            ["jobgpt", "behavioral", "Tell me about a time you led a project", "--resume", str(resume)],
+        )
+    assert result.exit_code == 0, result.output
+    call_args = client.chat.completions.create.call_args
+    user_msg = call_args.kwargs["messages"][1]["content"]
+    assert "Senior engineer at AWS" in user_msg
+
+
+def test_behavioral_missing_resume(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    result = runner.invoke(app, ["jobgpt", "behavioral", "Question", "--resume", "/nonexistent/resume.txt"])
+    assert result.exit_code != 0
+
+
+def test_ask_basic(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_ctor, _ = _make_openai_mock()
+    with patch("openai.OpenAI", mock_ctor):
+        result = runner.invoke(app, ["jobgpt", "ask", "What salary should I negotiate?"])
+    assert result.exit_code == 0, result.output
+    assert "Mocked AI response." in result.output
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    mock_ctor, _ = _make_openai_mock()
+    with patch("openai.OpenAI", mock_ctor):
+        result = runner.invoke(app, ["jobgpt", "ask", "Question"])
+    assert result.exit_code != 0
+
+
+def test_missing_openai_package(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    import sys
+    with patch.dict(sys.modules, {"openai": None}):
+        result = runner.invoke(app, ["jobgpt", "ask", "Question"])
+    assert result.exit_code != 0
+
+
+def test_system_prompt_used(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_ctor, client = _make_openai_mock()
+    with patch("openai.OpenAI", mock_ctor):
+        runner.invoke(app, ["jobgpt", "why-company", "Google"])
+    call_args = client.chat.completions.create.call_args
+    system_msg = call_args.kwargs["messages"][0]["content"]
+    assert "career coach" in system_msg.lower()


### PR DESCRIPTION
## Summary
This PR introduces `jobgpt`, a new AI-powered writing assistant subcommand for helping users craft compelling job application materials and interview answers. It integrates OpenAI's API to provide expert career coaching across multiple use cases.

## Key Changes
- **New `swelist/jobgpt.py` module** with three main commands:
  - `why-company`: Generate compelling answers to "Why do you want to work here?" questions
  - `behavioral`: Create STAR-format answers to behavioral interview questions with optional resume context
  - `ask`: General-purpose career and job-search advice
  
- **OpenAI integration** with:
  - Lazy import of the `openai` package with helpful error messaging if not installed
  - Environment variable validation for `OPENAI_API_KEY`
  - Configurable model selection (defaults to `gpt-4o`)
  - System prompts tailored to each use case (career coach persona)

- **Rich CLI output** with:
  - Markdown-formatted responses in styled panels
  - Optional clipboard copying via `xclip` (Linux) or `pbcopy` (macOS)
  - Graceful fallback if clipboard tools unavailable

- **Updated `swelist/main.py`** to register the new `jobgpt` subcommand

- **Updated `setup.py`** to:
  - Add `rich` as a core dependency
  - Add optional `ai` extras group with `openai>=1.0.0` for users who want AI features

## Notable Implementation Details
- Resume file reading is optional and gracefully handles missing files
- System prompts are centralized in `_SYSTEM_PROMPTS` dict for easy maintenance
- User message templates in `_USER_TEMPLATES` support variable interpolation
- Comprehensive test coverage in `tests/test_jobgpt.py` including mocked OpenAI calls, error cases, and resume file handling

https://claude.ai/code/session_01LhrYrLBj9FAzuxjJhjzQGW