### PR TITLE
Add HTML application-tracker dashboard (skill + native swelist command)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ build/
 # Misc
 .DS_Store
 *.log
+
+# Generated reports (personal output, e.g. from the html-report skill)
+reports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ swelist tracker update "Co — Role" --status "Rejected"
 swelist tracker get "Co — Role" # JSON lookup (exit 1 if not found)
 swelist tracker list            # display all tracked applications
 swelist tracker export --format json
+swelist tracker report          # generate a self-contained HTML dashboard
 ```
 
 Python 3.9–3.12 supported. Install dev deps: `pip install -r requirements.txt`
@@ -31,7 +32,8 @@ Python 3.9–3.12 supported. Install dev deps: `pip install -r requirements.txt`
 swelist/               Python package (CLI source)
   main.py              swelist run — job listings from SimplifyJobs GitHub repos
   jobgpt.py            swelist jobgpt — OpenAI-powered interview prep subcommands
-  tracker.py           swelist tracker — local SQLite application tracker (add/update/get/list/export)
+  tracker.py           swelist tracker — local SQLite application tracker (add/update/get/list/export/report)
+  report.py            HTML dashboard generator used by `swelist tracker report`
   agent.py             prototype: parses swelist output into JSON via LLM
 tests/                 pytest suite
 skills/                Claude Code skill files (see Skill System below)
@@ -52,12 +54,13 @@ README.md              user-facing documentation
 Three top-level commands:
 - `swelist run` — fetches live job JSON from GitHub, filters by timeframe/location, prints plain text
 - `swelist jobgpt <subcommand>` — delegates to `swelist/jobgpt.py` (requires `openai` extra)
-- `swelist tracker <subcommand>` — local SQLite application tracker (`swelist/tracker.py`); subcommands: `init`, `add`, `update`, `get`, `list`, `export`
+- `swelist tracker <subcommand>` — local SQLite application tracker (`swelist/tracker.py`); subcommands: `init`, `add`, `update`, `get`, `list`, `export`, `report`
 
 **Key conventions**:
 - Output is always plain text to stdout — no JSON, no color — so it can be piped to agents
 - No local state, no auth required for `swelist run`
 - `OPENAI_API_KEY` env var required only for jobgpt subcommands
+- `swelist tracker report` is the one command that writes a file (a self-contained HTML dashboard, default `reports/application-dashboard.html`) rather than only printing to stdout; it reads via `swelist/report.py` and adapts to whichever tracker schema columns exist (base v0.2.x or the richer v0.5.0 set with `company`/`tags`/`next_action`/etc.) — see `skills/html-report/SKILL.md` for the equivalent Claude-skill version of the same report
 
 ---
 
@@ -128,7 +131,8 @@ The `application-manager` skill needs these MCP tools allowed in `.claude/settin
 pytest                          # all tests
 pytest tests/test_main.py       # job listing tests only
 pytest tests/test_jobgpt.py     # jobgpt tests only (mocks OpenAI)
-pytest tests/test_tracker.py    # tracker tests (21 tests, 100% coverage)
+pytest tests/test_tracker.py    # tracker CLI tests (28 tests, 100% coverage)
+pytest tests/test_report.py     # HTML dashboard generator tests (report.py, 99% coverage)
 pytest --co -q                  # list all test names without running
 ```
 

--- a/skills/html-report/SKILL.md
+++ b/skills/html-report/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: HTML Report — Application Tracker Dashboard
-description: Generates a self-contained HTML dashboard (stat cards, Chart.js charts, filterable table) from a job search tracker CSV and application archives — opens directly in a browser, no server required
+description: Generates a self-contained HTML dashboard (stat cards, Chart.js charts, filterable table) from the same SQLite tracker database used by application-manager — opens directly in a browser, no server required
 summary: >
-  Use this skill to turn a `job_search_tracker.csv` file (and any
-  `documents/applications/*/outcome.md` archives) into a single self-contained
-  HTML dashboard. The report shows total/active/interview/offer/rejected stat
-  cards, a status-breakdown doughnut chart, sector and channel bar charts, an
-  application funnel chart, and a filterable, sortable table of every tracked
-  application. Everything — CSS, JS, and data — is inlined into one `.html`
-  file except the Chart.js library, which loads from a CDN on first open and
-  degrades gracefully to the stat cards if offline. The skill only reads
-  existing tracker data; it never writes back to the CSV or archives, so
-  re-running it after `/outcome` or manual edits is always safe.
-version: 0.1.0
+  Use this skill to turn the `applications` table in the shared SQLite
+  tracker (`~/.offerplus/applications.db`, same database and schema the
+  `job-application-manager` skill writes to) into a single self-contained
+  HTML dashboard. The report shows Active/Interview/Offer/Rejected stat
+  cards, a status-breakdown doughnut chart, a tags bar chart, an
+  applications-by-month bar chart, and a pipeline funnel chart, plus a
+  filterable, sortable table of every tracked application. Everything —
+  CSS, JS, and data — is inlined into one `.html` file except the Chart.js
+  library, which loads from a CDN on first open and degrades gracefully to
+  the stat cards if offline. The skill only reads the tracker database; it
+  never writes back, so re-running it after a Gmail sync or a manual
+  `swelist tracker update` is always safe.
+version: 0.2.0
 author: Yuan Chen
 repository: https://github.com/chenyuan99/swelist
 keywords:
@@ -22,7 +24,7 @@ keywords:
   - application-tracker
   - chart.js
   - reporting
-  - csv
+  - sqlite
   - data-visualization
 tags:
   - career
@@ -34,16 +36,13 @@ metadata:
   openclaw:
     emoji: "📊"
     requires:
-      bins: []
+      bins: ["sqlite3"]
       env: []
       mcp: []
     config:
-      - key: tracker_csv_path
-        description: Path to the job search tracker CSV
-        default: job_search_tracker.csv
-      - key: applications_archive_dir
-        description: Directory of per-application outcome archives (optional)
-        default: documents/applications/
+      - key: sqlite_db_path
+        description: Path to the shared SQLite tracker database (same value application-manager uses)
+        default: ~/.offerplus/applications.db
       - key: report_output_path
         description: Default output path for the generated dashboard
         default: reports/application-dashboard.html
@@ -58,28 +57,36 @@ Trigger when the user asks to:
 - Generate, build, or refresh a job search dashboard ("build me a dashboard", "generate the html report", "/html-report")
 - Visualize their application pipeline ("show me a chart of my applications", "visualize my job search")
 - Export a shareable, offline view of their tracker ("give me something I can open in a browser", "make a report I can send")
-- Re-run the dashboard after logging new outcomes ("refresh the dashboard", "update the report with my latest applications")
+- Re-run the dashboard after syncing new applications ("refresh the dashboard", "update the report with my latest applications")
 
 Keywords: `html report`, `dashboard`, `visualize applications`, `application chart`, `job search report`, `funnel chart`, `/html-report`
 
-This skill is **read-only**: it never modifies `job_search_tracker.csv` or the
-`documents/applications/` archive. Use the `job-application-manager` skill to
-update application status instead.
+This skill is **read-only**: it never modifies the tracker database. Use
+the `job-application-manager` skill (or `swelist tracker add/update`) to
+change application status — this skill only renders what's already there.
+
+**Requires the `sqlite` tracker backend.** If `profile.md` has
+`Tracker backend: notion`, this skill has nothing to read — see Edge Cases.
 
 ---
 
 ## Setup
 
-No MCP tools or credentials are required — this skill only reads local files
-and writes one HTML file.
+**Always read `skills/profile.md` first.** It's the same file
+`job-application-manager` reads, so both skills stay pointed at the same
+database.
 
-1. **Locate the tracker CSV** — default `job_search_tracker.csv` in the repo
-   root. If the user has configured a different path (e.g. in `profile.md`
-   under a future `Reporting` section), use that instead.
-2. **Locate the archive directory** — default `documents/applications/`.
-   Optional; if it doesn't exist, skip archive enrichment entirely (see
-   Edge Cases) and proceed with CSV data alone.
-3. **Resolve the output path** — default `reports/application-dashboard.html`.
+Resolve before continuing:
+
+1. **Tracker backend** — `Integrations > Tracker Backend`
+   - Must be `sqlite`. If `notion`, tell the user this report needs the
+     SQLite backend and stop (see Edge Cases) rather than fabricating data.
+2. **SQLite DB path** — `Integrations > Tracker Backend > SQLite DB path`
+   - Default: `~/.offerplus/applications.db`
+   - If the file doesn't exist: tell the user to run `swelist tracker init`
+     (or sync via `job-application-manager` first) — do not generate an
+     empty report silently.
+3. **Output path** — argument if given, else `reports/application-dashboard.html`.
    Create the `reports/` directory if it doesn't exist.
 
 ---
@@ -94,33 +101,65 @@ and writes one HTML file.
 
 ---
 
-## Config: Status Normalisation
+## Config: SQLite Schema (read-only)
 
-Map every tracker `status` value to one of five canonical buckets before
-computing stats. Comparisons are case-insensitive.
+Same table `job-application-manager` writes to. See that skill's
+"Config: SQLite Schema" section for the authoritative DDL and migration
+history. This skill never runs `ALTER TABLE` — it just adapts to whichever
+columns exist.
 
-| Tracker value | Canonical bucket | Colour |
-|---|---|---|
-| `applied` | Active | `#3b82f6` |
-| `interview` | Interview | `#f59e0b` |
-| `offer` | Offer | `#8b5cf6` |
-| `hired` | Hired | `#22c55e` |
-| `rejected`, `no_response`, `no response`, `offer_declined`, `interview_only`, `withdrawn` | Rejected/Closed | `#ef4444` |
-| any other/unrecognised value | Active (fallback) — note in the report footer as "N rows had an unmapped status" | `#3b82f6` |
+**Full (v0.5.0) schema:**
+
+```sql
+CREATE TABLE applications (
+  name           TEXT PRIMARY KEY,   -- "Company — Role Title"
+  status         TEXT NOT NULL,
+  job_id         TEXT,
+  company        TEXT,
+  applied_on     TEXT,               -- ISO date YYYY-MM-DD
+  last_touch     TEXT,               -- ISO date of most recent email
+  interview_date TEXT,               -- ISO date of next scheduled interview
+  next_action    TEXT,               -- Waiting | Prep | Follow up | Send availability
+  link           TEXT,               -- job posting or portal URL
+  tags           TEXT,               -- comma-separated e.g. "Referral,Remote"
+  notes          TEXT,
+  updated_at     TEXT DEFAULT (datetime('now'))
+);
+```
+
+**Older (v0.2.x) schema** only has `name, status, job_id, applied_on, notes,
+updated_at` — that's also exactly what `swelist tracker export` returns
+today. Check which columns are present before building the SELECT:
+
+```bash
+sqlite3 <DB_PATH> "PRAGMA table_info(applications);"
+```
+
+If `company`, `last_touch`, `interview_date`, `next_action`, `link`, or
+`tags` are missing, treat them as empty for every row and omit any
+chart/table section that depends entirely on them (see Layout, Edge Cases).
 
 ---
 
-## Config: CSV Columns
+## Config: Status Normalisation
 
-Expected columns in `job_search_tracker.csv`:
+Map every row's `status` value to one of five canonical buckets before
+computing stats. Comparisons are case-insensitive. Covers both the current
+pipeline statuses and the older v0.2.x values, so the report works
+regardless of which schema generation wrote the row.
 
-`date`, `company`, `sector`, `role`, `role_type`, `channel`, `status`,
-`contact_person`, `fit_rating`, `notes`, `cv_file`, `cover_letter_file`,
-`source`
+| Status value | Canonical bucket | Colour |
+|---|---|---|
+| `Applied / Received`, `OA`, `Recruiter screen`, `Not started` | Active | `#3b82f6` |
+| `Interviewing`, `In progress` | Interview | `#f59e0b` |
+| `Offer` | Offer | `#8b5cf6` |
+| `Hired`, `Done` | Hired | `#22c55e` |
+| `Rejected`, `Withdrawn` | Rejected/Closed | `#ef4444` |
+| any other/unrecognised value | Active (fallback) — note in the report footer as "N rows had an unmapped status" | `#3b82f6` |
 
-Columns with only empty values across all rows may be omitted from the
-rendered table (see Layout below). Missing columns entirely (older CSV
-versions) are treated as all-empty and omitted the same way — do not error.
+`In progress` (v0.2.x) can't be distinguished from a true "Interviewing"
+stage — bucket it as Interview and note in the footer that granular
+staging requires the v0.5.0 schema.
 
 ---
 
@@ -130,33 +169,34 @@ versions) are treated as all-empty and omitted the same way — do not error.
 INPUT: output_path (optional, default "reports/application-dashboard.html")
        open_flag (optional)
 
-STEP 0  Parse arguments
+STEP 0  Load profile + resolve DB
+  Read skills/profile.md → tracker_backend, DB_PATH
+  IF tracker_backend != "sqlite": stop, explain (see Edge Cases)
+  IF DB_PATH file does not exist: stop, tell user to run `swelist tracker init`
+
+STEP 1  Parse arguments
   IF path argument given: output_path = that path
   ELSE: output_path = "reports/application-dashboard.html"
   mkdir -p dirname(output_path)
 
-STEP 1  Collect data (read in parallel)
-  rows = parse_csv("job_search_tracker.csv")
-    # one record per row with the columns listed in Config: CSV Columns
-  IF documents/applications/ exists:
-    FOR each */outcome.md under documents/applications/:
-      outcome = parse_outcome_md(file)
-        # extract checked interview-stage checkboxes + free-text notes
-      match = fuzzy_match(outcome.company + outcome.role, rows,
-                           by = lowercase(strip_punctuation(company + role)))
-      IF match found: merge outcome into match.notes / match.stages
-      ELSE: attach outcome as unmatched extra context (still shown in report footer)
-  ELSE:
-    skip archive enrichment entirely (CSV-only mode)
+STEP 2  Collect data
+  columns = sqlite3 DB_PATH "PRAGMA table_info(applications);"
+  select_cols = ["name","status","job_id","applied_on","notes","updated_at"]
+                + any of ["company","last_touch","interview_date","next_action","link","tags"]
+                  that exist in columns
+  rows = sqlite3 -json DB_PATH
+    "SELECT {', '.join(select_cols)} FROM applications ORDER BY applied_on DESC, name ASC"
+  FOR each row:
+    row.company_display = row.company OR extract_company_from_name(row.name)  # part before " — "
+    row.role_display    = extract_role_from_name(row.name)                    # part after " — "
+    row.bucket           = normalise_status(row.status)   # Config: Status Normalisation
+    row.tag_list          = split(row.tags, ",") if present else []
 
-  FOR each row: row.bucket = normalise_status(row.status)   # Config: Status Normalisation
-
-STEP 2  Compute summary stats
+STEP 3  Compute summary stats
   total              = len(rows)
   by_bucket           = count rows grouped by row.bucket
-  by_sector           = count rows grouped by row.sector (blank → "Unspecified")
-  by_channel          = count rows grouped by row.channel into online / referral / other
-  by_period           = count rows grouped by row.date (year, or year extracted from full date)
+  by_tag              = count occurrences of each tag across row.tag_list (flatten)
+  by_month            = count rows grouped by YYYY-MM of row.applied_on (blank → "Unknown")
   resolved            = rows where bucket != "Active"
   past_screen         = rows where bucket IN ("Interview", "Offer", "Hired")
   funnel_rate_pct     = round(100 * len(past_screen) / total) if total else 0
@@ -166,18 +206,18 @@ STEP 2  Compute summary stats
                           Offer: count(bucket IN (Offer, Hired)),
                           Hired: count(bucket == Hired) }
 
-STEP 3  Generate HTML (see Layout, Design spec, and Charts below)
+STEP 4  Generate HTML (see Layout, Design spec, and Charts below)
   Build one self-contained HTML string:
     - inline <style> block (palette, cards, charts grid, table)
     - stat cards row
-    - two 2-column chart rows (doughnut, sector bar / channel bar, funnel bar)
-    - filterable table (search input + status/sector dropdowns, client-side JS)
-    - footer: "Generated by Claude Code · ai-job-search · {ISO date}"
+    - two 2-column chart rows (doughnut, tags bar / by-month bar, funnel bar)
+    - filterable table (search input + status/company dropdowns, client-side JS)
+    - footer: "Generated by Claude Code · swelist · {ISO date}"
   Charts render via Chart.js loaded from https://cdn.jsdelivr.net/npm/chart.js
     (only external dependency; wrap chart init in try/catch so a failed CDN
     fetch degrades to the stat cards instead of breaking the page)
 
-STEP 4  Write and confirm
+STEP 5  Write and confirm
   Write the complete HTML to output_path (Write tool — overwrite if it exists)
   IF open_flag: tell the user to open the file themselves (cannot launch a browser)
   Print the Report Format summary below
@@ -191,15 +231,15 @@ STEP 4  Write and confirm
 ┌─────────────────────────────────────────────┐
 │  🔍 Job Search Dashboard    Generated: DATE  │
 ├──────┬──────┬──────┬──────┬──────────────────┤
-│Total │Active│Inter-│Offer │Rejected/Closed   │  ← stat cards
-│  N   │  N   │view N│  N   │       N          │
+│Active│Inter-│Offer │Hired │Rejected/Closed   │  ← stat cards
+│  N   │view N│  N   │  N   │       N          │
 ├──────┴──────┴──────┴──────┴──────────────────┤
-│  Status breakdown (doughnut) │ By sector (bar)│  ← charts row
+│  Status breakdown (doughnut) │ By tag (bar)   │  ← charts row
 ├─────────────────────────────────────────────  ┤
-│  By channel (bar)  │  Funnel (horizontal bar) │  ← charts row
+│  By month (bar)    │  Funnel (horizontal bar) │  ← charts row
 ├──────────────────────────────────────────────  ┤
-│  Applications  [Status ▾] [Sector ▾] [🔍 ...]│  ← table with filters
-│  date │ company │ sector │ role │ status │ ... │
+│  Applications  [Status ▾] [Company ▾] [🔍 ...]│  ← table with filters
+│  date │ company │ role │ status │ next action │ ...│
 │  ...                                          │
 └───────────────────────────────────────────────┘
 ```
@@ -215,50 +255,62 @@ STEP 4  Write and confirm
 - **Table:**
   - Alternating row shading.
   - Status column uses a coloured pill/badge (Config: Status Normalisation colours).
-  - `source` column renders as a hyperlink (`target="_blank" rel="noopener"`)
-    if the value starts with `http`; otherwise render as plain text or `—`.
+  - `link` column renders as a hyperlink (`target="_blank" rel="noopener"`)
+    if present; otherwise `—`.
   - Empty cells render as `—`.
-  - Client-side filter: a text input filters rows across company + role +
-    sector; status and sector dropdowns filter independently; all three
-    combine with AND.
-  - Rows sort newest-first by default (`date` descending, then company A→Z).
+  - Client-side filter: a text input filters rows across company + role;
+    status and company dropdowns filter independently; all three combine
+    with AND.
+  - Rows sort newest-first by default (`applied_on` descending, then company A→Z).
 - **Responsive:** usable at 900px+; not required to be fully responsive below that.
-- **Footer:** `Generated by Claude Code · ai-job-search · {ISO date}`.
+- **Footer:** `Generated by Claude Code · swelist · {ISO date}`.
 
 ## Charts (Chart.js)
 
 1. **Status doughnut** — one slice per status bucket, palette colours above.
-2. **By sector bar** (horizontal) — application count per sector, sorted descending.
-3. **By channel bar** — online / referral / other.
-4. **Application funnel** (horizontal bar) — Applied → Interview → Offer → Hired,
-   each bar = count of rows reaching at least that stage.
+2. **By tag bar** (horizontal) — count per inferred tag (`Referral`, `Remote`,
+   `Urgent`, `Visa` — see `job-application-manager`'s Tag Inference config),
+   sorted descending. Omit entirely if no row has a `tags` value.
+3. **By month bar** — application count per `YYYY-MM` of `applied_on`, oldest
+   to newest.
+4. **Application funnel** (horizontal bar) — Applied → Interview → Offer →
+   Hired, each bar = count of rows reaching at least that stage.
 
 All chart `<canvas>` elements get an `aria-label`. Wrap each chart in
 `<div class="chart-card"><h3>Title</h3><canvas ...></canvas></div>`.
 
 ## Table Columns
 
-`Date` · `Company` · `Role` · `Sector` · `Channel` · `Status` · `Notes`
-(truncate to 80 chars, full text in a `title` tooltip) · `Source` (link or `—`)
+`Date` (`applied_on`) · `Company` · `Role` · `Status` · `Next action` ·
+`Tags` · `Interview date` · `Notes` (truncate to 80 chars, full text in a
+`title` tooltip) · `Link` (hyperlink or `—`)
 
-Omit any column whose value is empty across every row.
+Omit any column whose value is empty across every row, and omit
+`next_action` / `interview_date` / `tags` / `link` entirely if the column
+doesn't exist in the DB (v0.2.x schema).
 
 ---
 
 ## File I/O Reference
 
-### Reading the tracker CSV
-```
-rows = read_csv("job_search_tracker.csv")
-# each row → dict keyed by: date, company, sector, role, role_type, channel,
-# status, contact_person, fit_rating, notes, cv_file, cover_letter_file, source
+### Checking available columns
+```bash
+sqlite3 ~/.offerplus/applications.db "PRAGMA table_info(applications);"
 ```
 
-### Reading an outcome archive
+### Reading tracker rows (full v0.5.0 schema)
+```bash
+sqlite3 -json ~/.offerplus/applications.db \
+  "SELECT name, status, job_id, company, applied_on, last_touch, interview_date,
+          next_action, link, tags, notes, updated_at
+   FROM applications ORDER BY applied_on DESC, name ASC;"
 ```
-outcome = read_file("documents/applications/<company-role-slug>/outcome.md")
-# extract: checked "- [x] Stage name" checkboxes → stages reached
-#          any free-text notes below the checklist
+
+### Reading tracker rows (older v0.2.x schema fallback)
+```bash
+sqlite3 -json ~/.offerplus/applications.db \
+  "SELECT name, status, job_id, applied_on, notes, updated_at
+   FROM applications ORDER BY applied_on DESC, name ASC;"
 ```
 
 ### Writing the report
@@ -277,10 +329,11 @@ Open it in any browser — no server needed.
 
 Summary:
 - Total applications: N
-- Active: N · Interview: N · Hired: N · Rejected/Closed: N
+- Active: N · Interview: N · Offer: N · Hired: N · Rejected/Closed: N
 - Funnel: N% progressed past resume screen
 
-Re-run /html-report any time after adding new entries via /outcome to refresh the dashboard.
+Re-run /html-report any time after syncing via application-manager
+(or `swelist tracker add/update`) to refresh the dashboard.
 ```
 
 (Omit the funnel line if `total == 0`; print "No applications tracked yet" instead of the stat breakdown.)
@@ -290,10 +343,11 @@ Re-run /html-report any time after adding new entries via /outcome to refresh th
 ## Design Principles
 
 - **Self-contained.** One file, opens offline (Chart.js needs a CDN fetch once; everything else is local).
-- **Data-only.** This skill reads and renders; it never writes to the tracker CSV or the archive.
+- **Data-only.** This skill reads and renders; it never writes to the tracker database.
 - **Idempotent.** Re-running overwrites the previous report at the same path — no accumulation.
+- **Single source of truth.** Reads the exact same SQLite database `job-application-manager` writes to — no separate export/CSV step, so the dashboard is never stale relative to a sync that already happened.
 - **Graceful on sparse data.** With only a few rows, charts still render correctly for small N; the table remains the primary value. Never suppress charts just because N is small.
-- **No fabrication.** Every number in the report comes directly from the CSV or outcome files. Never infer or estimate missing fields.
+- **No fabrication.** Every number in the report comes directly from the tracker database. Never infer or estimate missing fields.
 
 ---
 
@@ -301,14 +355,15 @@ Re-run /html-report any time after adding new entries via /outcome to refresh th
 
 | Situation | Handling |
 |---|---|
-| `job_search_tracker.csv` does not exist | Tell the user the CSV was not found and the expected path; do not generate an empty report |
-| CSV exists but has zero data rows | Still generate the HTML shell; show "No applications tracked yet" instead of stat cards/charts |
-| `documents/applications/` does not exist | Skip archive enrichment silently; proceed in CSV-only mode |
-| An archive folder has no matching CSV row (by fuzzy company+role match) | Attach it as unmatched extra context in the report footer rather than dropping it |
-| A CSV row has a `status` value not in the normalisation table | Fall back to `Active`; count it in an "N rows had an unmapped status" footer note |
-| `date` is a bare year (e.g. `2025`) vs. a full date | Group by year either way; sort full dates before bare years within the same year |
-| `source` value doesn't start with `http` | Render as plain text, not a link |
-| A column (e.g. `contact_person`) is empty for every row | Omit that column from the rendered table entirely |
+| `Tracker backend` in `profile.md` is `notion`, not `sqlite` | Stop and tell the user this skill currently only reads the SQLite tracker; offer to switch `tracker_backend` to `sqlite` in `profile.md`, or point at an explicit `--db` path if they maintain a separate local copy |
+| SQLite DB file does not exist at the resolved path | Tell the user to run `swelist tracker init` (or do an initial sync via `job-application-manager`); do not generate an empty report |
+| DB exists but `applications` table has zero rows | Still generate the HTML shell; show "No applications tracked yet" instead of stat cards/charts |
+| DB uses the older v0.2.x schema (no `company`/`tags`/etc.) | Build the SELECT from only the columns that exist (Step 2); omit dependent chart/table columns entirely rather than erroring |
+| A row's `status` value isn't in the normalisation table | Fall back to `Active`; count it in an "N rows had an unmapped status" footer note |
+| `applied_on` is null or blank | Group under "Unknown" in the by-month chart; sort such rows last in the table |
+| No row has a `tags` value | Omit the "By tag" chart entirely rather than rendering an empty one |
+| `link` value doesn't start with `http` | Render as plain text, not a hyperlink |
+| A table column (e.g. `next_action`) is empty for every row | Omit that column from the rendered table entirely |
 | Output path's parent directory doesn't exist | Create it (`mkdir -p`) before writing |
 | Re-running with the same output path | Overwrite; never append or version the filename |
 | User is offline when the report is later opened | Chart.js CDN fetch fails; charts area shows nothing but stat cards and table still render — never let a failed script tag blank the whole page |

--- a/skills/html-report/SKILL.md
+++ b/skills/html-report/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: HTML Report — Application Tracker Dashboard
+description: Generates a self-contained HTML dashboard (stat cards, Chart.js charts, filterable table) from a job search tracker CSV and application archives — opens directly in a browser, no server required
+summary: >
+  Use this skill to turn a `job_search_tracker.csv` file (and any
+  `documents/applications/*/outcome.md` archives) into a single self-contained
+  HTML dashboard. The report shows total/active/interview/offer/rejected stat
+  cards, a status-breakdown doughnut chart, sector and channel bar charts, an
+  application funnel chart, and a filterable, sortable table of every tracked
+  application. Everything — CSS, JS, and data — is inlined into one `.html`
+  file except the Chart.js library, which loads from a CDN on first open and
+  degrades gracefully to the stat cards if offline. The skill only reads
+  existing tracker data; it never writes back to the CSV or archives, so
+  re-running it after `/outcome` or manual edits is always safe.
+version: 0.1.0
+author: Yuan Chen
+repository: https://github.com/chenyuan99/swelist
+keywords:
+  - html-report
+  - dashboard
+  - job-search
+  - application-tracker
+  - chart.js
+  - reporting
+  - csv
+  - data-visualization
+tags:
+  - career
+  - productivity
+  - reporting
+  - job-search
+category: career
+metadata:
+  openclaw:
+    emoji: "📊"
+    requires:
+      bins: []
+      env: []
+      mcp: []
+    config:
+      - key: tracker_csv_path
+        description: Path to the job search tracker CSV
+        default: job_search_tracker.csv
+      - key: applications_archive_dir
+        description: Directory of per-application outcome archives (optional)
+        default: documents/applications/
+      - key: report_output_path
+        description: Default output path for the generated dashboard
+        default: reports/application-dashboard.html
+---
+
+# HTML Report — Application Tracker Dashboard
+
+## When to Use This Skill
+
+Trigger when the user asks to:
+
+- Generate, build, or refresh a job search dashboard ("build me a dashboard", "generate the html report", "/html-report")
+- Visualize their application pipeline ("show me a chart of my applications", "visualize my job search")
+- Export a shareable, offline view of their tracker ("give me something I can open in a browser", "make a report I can send")
+- Re-run the dashboard after logging new outcomes ("refresh the dashboard", "update the report with my latest applications")
+
+Keywords: `html report`, `dashboard`, `visualize applications`, `application chart`, `job search report`, `funnel chart`, `/html-report`
+
+This skill is **read-only**: it never modifies `job_search_tracker.csv` or the
+`documents/applications/` archive. Use the `job-application-manager` skill to
+update application status instead.
+
+---
+
+## Setup
+
+No MCP tools or credentials are required — this skill only reads local files
+and writes one HTML file.
+
+1. **Locate the tracker CSV** — default `job_search_tracker.csv` in the repo
+   root. If the user has configured a different path (e.g. in `profile.md`
+   under a future `Reporting` section), use that instead.
+2. **Locate the archive directory** — default `documents/applications/`.
+   Optional; if it doesn't exist, skip archive enrichment entirely (see
+   Edge Cases) and proceed with CSV data alone.
+3. **Resolve the output path** — default `reports/application-dashboard.html`.
+   Create the `reports/` directory if it doesn't exist.
+
+---
+
+## Config: Argument Parsing
+
+| Input | Behavior |
+|---|---|
+| No argument | Output to `reports/application-dashboard.html` |
+| A path argument (e.g. `/html-report ~/Desktop/report.html`) | Use that path instead |
+| `--open` flag | After writing, tell the user to open the file — the skill cannot launch a browser itself |
+
+---
+
+## Config: Status Normalisation
+
+Map every tracker `status` value to one of five canonical buckets before
+computing stats. Comparisons are case-insensitive.
+
+| Tracker value | Canonical bucket | Colour |
+|---|---|---|
+| `applied` | Active | `#3b82f6` |
+| `interview` | Interview | `#f59e0b` |
+| `offer` | Offer | `#8b5cf6` |
+| `hired` | Hired | `#22c55e` |
+| `rejected`, `no_response`, `no response`, `offer_declined`, `interview_only`, `withdrawn` | Rejected/Closed | `#ef4444` |
+| any other/unrecognised value | Active (fallback) — note in the report footer as "N rows had an unmapped status" | `#3b82f6` |
+
+---
+
+## Config: CSV Columns
+
+Expected columns in `job_search_tracker.csv`:
+
+`date`, `company`, `sector`, `role`, `role_type`, `channel`, `status`,
+`contact_person`, `fit_rating`, `notes`, `cv_file`, `cover_letter_file`,
+`source`
+
+Columns with only empty values across all rows may be omitted from the
+rendered table (see Layout below). Missing columns entirely (older CSV
+versions) are treated as all-empty and omitted the same way — do not error.
+
+---
+
+## Workflow
+
+```
+INPUT: output_path (optional, default "reports/application-dashboard.html")
+       open_flag (optional)
+
+STEP 0  Parse arguments
+  IF path argument given: output_path = that path
+  ELSE: output_path = "reports/application-dashboard.html"
+  mkdir -p dirname(output_path)
+
+STEP 1  Collect data (read in parallel)
+  rows = parse_csv("job_search_tracker.csv")
+    # one record per row with the columns listed in Config: CSV Columns
+  IF documents/applications/ exists:
+    FOR each */outcome.md under documents/applications/:
+      outcome = parse_outcome_md(file)
+        # extract checked interview-stage checkboxes + free-text notes
+      match = fuzzy_match(outcome.company + outcome.role, rows,
+                           by = lowercase(strip_punctuation(company + role)))
+      IF match found: merge outcome into match.notes / match.stages
+      ELSE: attach outcome as unmatched extra context (still shown in report footer)
+  ELSE:
+    skip archive enrichment entirely (CSV-only mode)
+
+  FOR each row: row.bucket = normalise_status(row.status)   # Config: Status Normalisation
+
+STEP 2  Compute summary stats
+  total              = len(rows)
+  by_bucket           = count rows grouped by row.bucket
+  by_sector           = count rows grouped by row.sector (blank → "Unspecified")
+  by_channel          = count rows grouped by row.channel into online / referral / other
+  by_period           = count rows grouped by row.date (year, or year extracted from full date)
+  resolved            = rows where bucket != "Active"
+  past_screen         = rows where bucket IN ("Interview", "Offer", "Hired")
+  funnel_rate_pct     = round(100 * len(past_screen) / total) if total else 0
+  rejection_rate_pct  = round(100 * count(bucket == "Rejected/Closed") / len(resolved)) if resolved else 0
+  funnel_stages       = { Applied: total,
+                          Interview: count(bucket IN (Interview, Offer, Hired)),
+                          Offer: count(bucket IN (Offer, Hired)),
+                          Hired: count(bucket == Hired) }
+
+STEP 3  Generate HTML (see Layout, Design spec, and Charts below)
+  Build one self-contained HTML string:
+    - inline <style> block (palette, cards, charts grid, table)
+    - stat cards row
+    - two 2-column chart rows (doughnut, sector bar / channel bar, funnel bar)
+    - filterable table (search input + status/sector dropdowns, client-side JS)
+    - footer: "Generated by Claude Code · ai-job-search · {ISO date}"
+  Charts render via Chart.js loaded from https://cdn.jsdelivr.net/npm/chart.js
+    (only external dependency; wrap chart init in try/catch so a failed CDN
+    fetch degrades to the stat cards instead of breaking the page)
+
+STEP 4  Write and confirm
+  Write the complete HTML to output_path (Write tool — overwrite if it exists)
+  IF open_flag: tell the user to open the file themselves (cannot launch a browser)
+  Print the Report Format summary below
+```
+
+---
+
+## Layout
+
+```
+┌─────────────────────────────────────────────┐
+│  🔍 Job Search Dashboard    Generated: DATE  │
+├──────┬──────┬──────┬──────┬──────────────────┤
+│Total │Active│Inter-│Offer │Rejected/Closed   │  ← stat cards
+│  N   │  N   │view N│  N   │       N          │
+├──────┴──────┴──────┴──────┴──────────────────┤
+│  Status breakdown (doughnut) │ By sector (bar)│  ← charts row
+├─────────────────────────────────────────────  ┤
+│  By channel (bar)  │  Funnel (horizontal bar) │  ← charts row
+├──────────────────────────────────────────────  ┤
+│  Applications  [Status ▾] [Sector ▾] [🔍 ...]│  ← table with filters
+│  date │ company │ sector │ role │ status │ ... │
+│  ...                                          │
+└───────────────────────────────────────────────┘
+```
+
+## Design Spec
+
+- **Colour palette:** CSS custom properties, using the status colours in
+  Config: Status Normalisation above.
+- **Font:** system-ui stack, no web fonts.
+- **Stat cards:** white background, subtle shadow, large bold number, label
+  below, left border in the status colour.
+- **Charts:** 2-column grid on wide screens, stacked on narrow (`<768px`).
+- **Table:**
+  - Alternating row shading.
+  - Status column uses a coloured pill/badge (Config: Status Normalisation colours).
+  - `source` column renders as a hyperlink (`target="_blank" rel="noopener"`)
+    if the value starts with `http`; otherwise render as plain text or `—`.
+  - Empty cells render as `—`.
+  - Client-side filter: a text input filters rows across company + role +
+    sector; status and sector dropdowns filter independently; all three
+    combine with AND.
+  - Rows sort newest-first by default (`date` descending, then company A→Z).
+- **Responsive:** usable at 900px+; not required to be fully responsive below that.
+- **Footer:** `Generated by Claude Code · ai-job-search · {ISO date}`.
+
+## Charts (Chart.js)
+
+1. **Status doughnut** — one slice per status bucket, palette colours above.
+2. **By sector bar** (horizontal) — application count per sector, sorted descending.
+3. **By channel bar** — online / referral / other.
+4. **Application funnel** (horizontal bar) — Applied → Interview → Offer → Hired,
+   each bar = count of rows reaching at least that stage.
+
+All chart `<canvas>` elements get an `aria-label`. Wrap each chart in
+`<div class="chart-card"><h3>Title</h3><canvas ...></canvas></div>`.
+
+## Table Columns
+
+`Date` · `Company` · `Role` · `Sector` · `Channel` · `Status` · `Notes`
+(truncate to 80 chars, full text in a `title` tooltip) · `Source` (link or `—`)
+
+Omit any column whose value is empty across every row.
+
+---
+
+## File I/O Reference
+
+### Reading the tracker CSV
+```
+rows = read_csv("job_search_tracker.csv")
+# each row → dict keyed by: date, company, sector, role, role_type, channel,
+# status, contact_person, fit_rating, notes, cv_file, cover_letter_file, source
+```
+
+### Reading an outcome archive
+```
+outcome = read_file("documents/applications/<company-role-slug>/outcome.md")
+# extract: checked "- [x] Stage name" checkboxes → stages reached
+#          any free-text notes below the checklist
+```
+
+### Writing the report
+```
+Write(file_path=output_path, content=full_html_string)
+```
+
+---
+
+## Report Format
+
+```
+Dashboard generated: <output path>
+
+Open it in any browser — no server needed.
+
+Summary:
+- Total applications: N
+- Active: N · Interview: N · Hired: N · Rejected/Closed: N
+- Funnel: N% progressed past resume screen
+
+Re-run /html-report any time after adding new entries via /outcome to refresh the dashboard.
+```
+
+(Omit the funnel line if `total == 0`; print "No applications tracked yet" instead of the stat breakdown.)
+
+---
+
+## Design Principles
+
+- **Self-contained.** One file, opens offline (Chart.js needs a CDN fetch once; everything else is local).
+- **Data-only.** This skill reads and renders; it never writes to the tracker CSV or the archive.
+- **Idempotent.** Re-running overwrites the previous report at the same path — no accumulation.
+- **Graceful on sparse data.** With only a few rows, charts still render correctly for small N; the table remains the primary value. Never suppress charts just because N is small.
+- **No fabrication.** Every number in the report comes directly from the CSV or outcome files. Never infer or estimate missing fields.
+
+---
+
+## Edge Cases
+
+| Situation | Handling |
+|---|---|
+| `job_search_tracker.csv` does not exist | Tell the user the CSV was not found and the expected path; do not generate an empty report |
+| CSV exists but has zero data rows | Still generate the HTML shell; show "No applications tracked yet" instead of stat cards/charts |
+| `documents/applications/` does not exist | Skip archive enrichment silently; proceed in CSV-only mode |
+| An archive folder has no matching CSV row (by fuzzy company+role match) | Attach it as unmatched extra context in the report footer rather than dropping it |
+| A CSV row has a `status` value not in the normalisation table | Fall back to `Active`; count it in an "N rows had an unmapped status" footer note |
+| `date` is a bare year (e.g. `2025`) vs. a full date | Group by year either way; sort full dates before bare years within the same year |
+| `source` value doesn't start with `http` | Render as plain text, not a link |
+| A column (e.g. `contact_person`) is empty for every row | Omit that column from the rendered table entirely |
+| Output path's parent directory doesn't exist | Create it (`mkdir -p`) before writing |
+| Re-running with the same output path | Overwrite; never append or version the filename |
+| User is offline when the report is later opened | Chart.js CDN fetch fails; charts area shows nothing but stat cards and table still render — never let a failed script tag blank the whole page |
+| `--open` flag passed | Tell the user the file is ready and where it is; the skill cannot launch a browser itself |

--- a/skills/profile.md
+++ b/skills/profile.md
@@ -75,6 +75,7 @@ Which sections each skill uses — so you know what to fill in:
 | Skill | Sections needed |
 |---|---|
 | `application-manager` | Integrations (Tracker Backend + Gmail + Notion or SQLite), Personal Info (career email) |
+| `html-report` | Integrations (Tracker Backend — requires SQLite) |
 | `resume-tailor` | Personal Info, Career Profile, Resume |
 | `cover-letter-generator` | Personal Info, Career Profile, Resume |
 | `interview-prep-generator` | Personal Info, Career Profile, Resume |

--- a/swelist/report.py
+++ b/swelist/report.py
@@ -1,0 +1,337 @@
+"""Self-contained HTML dashboard generator for the SQLite application tracker.
+
+Reads the same `applications` table the `tracker` subcommands write to and
+renders a single offline-friendly `.html` file: stat cards, Chart.js charts,
+and a filterable table. Chart.js itself loads from a CDN on first open;
+everything else (CSS, JS, data) is inlined.
+"""
+
+import json
+import os
+import sqlite3
+from collections import Counter
+from datetime import date
+from html import escape
+from typing import Optional
+
+BASE_COLUMNS = ["name", "status", "job_id", "applied_on", "notes", "updated_at"]
+EXTRA_COLUMNS = ["company", "last_touch", "interview_date", "next_action", "link", "tags"]
+
+BUCKET_ORDER = ["Active", "Interview", "Offer", "Hired", "Rejected/Closed"]
+
+BUCKET_COLORS = {
+    "Active": "#3b82f6",
+    "Interview": "#f59e0b",
+    "Offer": "#8b5cf6",
+    "Hired": "#22c55e",
+    "Rejected/Closed": "#ef4444",
+}
+
+# Covers both the current pipeline statuses and the older Not started/In
+# progress/Rejected/Done schema, so the report works against either.
+STATUS_BUCKETS = {
+    "applied / received": "Active",
+    "oa": "Active",
+    "recruiter screen": "Active",
+    "not started": "Active",
+    "interviewing": "Interview",
+    "in progress": "Interview",
+    "offer": "Offer",
+    "hired": "Hired",
+    "done": "Hired",
+    "rejected": "Rejected/Closed",
+    "withdrawn": "Rejected/Closed",
+}
+
+
+def _normalise_status(status: Optional[str]) -> str:
+    return STATUS_BUCKETS.get((status or "").strip().lower(), "Active")
+
+
+def _split_name(name: str) -> "tuple[str, str]":
+    if " — " in name:
+        company, role = name.split(" — ", 1)
+        return company, role
+    return name, ""
+
+
+def _available_columns(conn: sqlite3.Connection) -> "list[str]":
+    existing = {row["name"] for row in conn.execute("PRAGMA table_info(applications)")}
+    return BASE_COLUMNS + [c for c in EXTRA_COLUMNS if c in existing]
+
+
+def fetch_rows(db_path: str) -> "list[dict]":
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    columns = _available_columns(conn)
+    query = f"SELECT {', '.join(columns)} FROM applications ORDER BY applied_on DESC, name ASC"
+    rows = [dict(r) for r in conn.execute(query)]
+    conn.close()
+
+    for row in rows:
+        company, role = _split_name(row["name"])
+        row["company_display"] = row.get("company") or company
+        row["role_display"] = role
+        row["bucket"] = _normalise_status(row.get("status"))
+        tags = row.get("tags") or ""
+        row["tag_list"] = [t.strip() for t in tags.split(",") if t.strip()]
+    return rows
+
+
+def compute_stats(rows: "list[dict]") -> dict:
+    total = len(rows)
+    by_bucket = Counter(r["bucket"] for r in rows)
+    by_tag = Counter(t for r in rows for t in r["tag_list"])
+    by_month: Counter = Counter()
+    for r in rows:
+        applied = (r.get("applied_on") or "").strip()
+        month = applied[:7] if len(applied) >= 7 else "Unknown"
+        by_month[month] += 1
+
+    resolved = [r for r in rows if r["bucket"] != "Active"]
+    past_screen = [r for r in rows if r["bucket"] in ("Interview", "Offer", "Hired")]
+    rejected = by_bucket.get("Rejected/Closed", 0)
+
+    funnel_stages = {
+        "Applied": total,
+        "Interview": sum(by_bucket.get(b, 0) for b in ("Interview", "Offer", "Hired")),
+        "Offer": sum(by_bucket.get(b, 0) for b in ("Offer", "Hired")),
+        "Hired": by_bucket.get("Hired", 0),
+    }
+
+    return {
+        "total": total,
+        "by_bucket": by_bucket,
+        "by_tag": by_tag,
+        "by_month": dict(sorted(by_month.items())),
+        "funnel_stages": funnel_stages,
+        "funnel_pct": round(100 * len(past_screen) / total) if total else 0,
+        "rejection_pct": round(100 * rejected / len(resolved)) if resolved else 0,
+        "unmapped_statuses": sorted(
+            {r["status"] for r in rows if (r.get("status") or "").strip().lower() not in STATUS_BUCKETS}
+        ),
+    }
+
+
+def _e(value) -> str:
+    return escape(str(value)) if value not in (None, "") else "—"
+
+
+def _table_rows_html(rows: "list[dict]") -> str:
+    out = []
+    for r in rows:
+        link = r.get("link") or ""
+        if link.startswith("http"):
+            link_html = f'<a href="{escape(link)}" target="_blank" rel="noopener">{escape(link)}</a>'
+        else:
+            link_html = _e(link)
+
+        notes = r.get("notes") or ""
+        notes_short = notes if len(notes) <= 80 else notes[:77] + "..."
+        notes_html = f'<span title="{escape(notes)}">{_e(notes_short)}</span>' if notes else "—"
+
+        out.append(
+            "<tr data-status=\"{bucket}\" data-company=\"{company}\">"
+            "<td>{applied_on}</td><td>{company_disp}</td><td>{role}</td>"
+            "<td><span class=\"pill\" style=\"background:{color}\">{bucket}</span></td>"
+            "<td>{next_action}</td><td>{tags}</td><td>{interview_date}</td>"
+            "<td>{notes}</td><td>{link}</td></tr>".format(
+                bucket=escape(r["bucket"]),
+                company=escape(r["company_display"]),
+                applied_on=_e(r.get("applied_on")),
+                company_disp=_e(r["company_display"]),
+                role=_e(r["role_display"]),
+                color=BUCKET_COLORS[r["bucket"]],
+                next_action=_e(r.get("next_action")),
+                tags=_e(", ".join(r["tag_list"])),
+                interview_date=_e(r.get("interview_date")),
+                notes=notes_html,
+                link=link_html,
+            )
+        )
+    return "\n".join(out)
+
+
+def render_html(rows: "list[dict]", stats: dict) -> str:
+    generated = date.today().isoformat()
+
+    stat_cards = "".join(
+        f'<div class="card" style="border-left-color:{BUCKET_COLORS[b]}">'
+        f'<div class="num">{stats["by_bucket"].get(b, 0)}</div><div class="label">{b}</div></div>'
+        for b in BUCKET_ORDER
+    )
+
+    chart_data = {
+        "status": {
+            "labels": BUCKET_ORDER,
+            "data": [stats["by_bucket"].get(b, 0) for b in BUCKET_ORDER],
+            "colors": [BUCKET_COLORS[b] for b in BUCKET_ORDER],
+        },
+        "tags": {
+            "labels": [t for t, _ in stats["by_tag"].most_common()],
+            "data": [n for _, n in stats["by_tag"].most_common()],
+        },
+        "month": {
+            "labels": list(stats["by_month"].keys()),
+            "data": list(stats["by_month"].values()),
+        },
+        "funnel": {
+            "labels": list(stats["funnel_stages"].keys()),
+            "data": list(stats["funnel_stages"].values()),
+        },
+    }
+
+    if stats["total"] == 0:
+        body_main = "<p class=\"empty\">No applications tracked yet. Run <code>swelist tracker add</code> to get started.</p>"
+    else:
+        body_main = f"""
+<section class="cards">{stat_cards}</section>
+<section class="charts-grid">
+  <div class="chart-card"><h3>Status breakdown</h3><canvas id="statusChart" aria-label="Status breakdown"></canvas></div>
+  <div class="chart-card"><h3>By tag</h3><canvas id="tagChart" aria-label="Applications by tag"></canvas></div>
+</section>
+<section class="charts-grid">
+  <div class="chart-card"><h3>By month</h3><canvas id="monthChart" aria-label="Applications by month"></canvas></div>
+  <div class="chart-card"><h3>Funnel</h3><canvas id="funnelChart" aria-label="Application funnel"></canvas></div>
+</section>
+<section class="table-card">
+  <div class="filters">
+    <input id="search" type="text" placeholder="Search company or role...">
+    <select id="statusFilter"><option value="">All statuses</option>
+      {"".join(f'<option value="{b}">{b}</option>' for b in BUCKET_ORDER)}
+    </select>
+    <select id="companyFilter"><option value="">All companies</option>
+      {"".join(f'<option value="{escape(c)}">{escape(c)}</option>' for c in sorted({r["company_display"] for r in rows}))}
+    </select>
+  </div>
+  <table>
+    <thead><tr><th>Date</th><th>Company</th><th>Role</th><th>Status</th>
+    <th>Next action</th><th>Tags</th><th>Interview date</th><th>Notes</th><th>Link</th></tr></thead>
+    <tbody id="rows">{_table_rows_html(rows)}</tbody>
+  </table>
+</section>
+"""
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Job Search Dashboard</title>
+<style>
+  :root {{
+    --bg: #f8fafc; --card: #ffffff; --text: #0f172a; --muted: #64748b; --border: #e2e8f0;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg); color: var(--text); margin: 0; padding: 24px; min-width: 900px;
+  }}
+  header {{ display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 20px; }}
+  header h1 {{ font-size: 1.5rem; margin: 0; }}
+  .cards {{ display: grid; grid-template-columns: repeat(5, 1fr); gap: 16px; margin-bottom: 24px; }}
+  .card {{ background: var(--card); border-radius: 10px; padding: 16px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.08); border-left: 4px solid; }}
+  .card .num {{ font-size: 1.8rem; font-weight: 700; }}
+  .card .label {{ color: var(--muted); font-size: .85rem; }}
+  .charts-grid {{ display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }}
+  .chart-card {{ background: var(--card); border-radius: 10px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }}
+  .chart-card h3 {{ margin: 0 0 12px; font-size: 1rem; }}
+  .table-card {{ background: var(--card); border-radius: 10px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }}
+  .filters {{ display: flex; gap: 8px; margin-bottom: 12px; }}
+  .filters input, .filters select {{ padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; }}
+  table {{ width: 100%; border-collapse: collapse; }}
+  th, td {{ text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); font-size: .875rem; }}
+  tbody tr:nth-child(even) {{ background: #f8fafc; }}
+  .pill {{ color: #fff; padding: 2px 8px; border-radius: 999px; font-size: .75rem; }}
+  .empty {{ color: var(--muted); padding: 40px; text-align: center; }}
+  footer {{ margin-top: 24px; color: var(--muted); font-size: .8rem; text-align: center; }}
+  @media (max-width: 1100px) {{ .cards {{ grid-template-columns: repeat(3, 1fr); }} }}
+</style>
+</head>
+<body>
+<header><h1>🔍 Job Search Dashboard</h1><span>Generated: {generated}</span></header>
+{body_main}
+<footer>Generated by swelist &middot; {generated}</footer>
+<script>
+const CHART_DATA = {json.dumps(chart_data)};
+try {{
+  const s = document.createElement('script');
+  s.src = 'https://cdn.jsdelivr.net/npm/chart.js';
+  s.onload = renderCharts;
+  document.head.appendChild(s);
+}} catch (e) {{ /* charts degrade to stat cards */ }}
+
+function renderCharts() {{
+  try {{
+    if (document.getElementById('statusChart')) {{
+      new Chart(document.getElementById('statusChart'), {{
+        type: 'doughnut',
+        data: {{ labels: CHART_DATA.status.labels,
+          datasets: [{{ data: CHART_DATA.status.data, backgroundColor: CHART_DATA.status.colors }}] }}
+      }});
+    }}
+    if (document.getElementById('tagChart') && CHART_DATA.tags.labels.length) {{
+      new Chart(document.getElementById('tagChart'), {{
+        type: 'bar',
+        data: {{ labels: CHART_DATA.tags.labels, datasets: [{{ data: CHART_DATA.tags.data, backgroundColor: '#3b82f6' }}] }},
+        options: {{ indexAxis: 'y' }}
+      }});
+    }}
+    if (document.getElementById('monthChart')) {{
+      new Chart(document.getElementById('monthChart'), {{
+        type: 'bar',
+        data: {{ labels: CHART_DATA.month.labels, datasets: [{{ data: CHART_DATA.month.data, backgroundColor: '#8b5cf6' }}] }}
+      }});
+    }}
+    if (document.getElementById('funnelChart')) {{
+      new Chart(document.getElementById('funnelChart'), {{
+        type: 'bar',
+        data: {{ labels: CHART_DATA.funnel.labels,
+          datasets: [{{ data: CHART_DATA.funnel.data, backgroundColor: '#22c55e' }}] }},
+        options: {{ indexAxis: 'y' }}
+      }});
+    }}
+  }} catch (e) {{ /* charts degrade to stat cards on any Chart.js failure */ }}
+}}
+
+(function filters() {{
+  const search = document.getElementById('search');
+  const statusFilter = document.getElementById('statusFilter');
+  const companyFilter = document.getElementById('companyFilter');
+  if (!search) return;
+  function apply() {{
+    const q = search.value.toLowerCase();
+    const status = statusFilter.value;
+    const company = companyFilter.value;
+    document.querySelectorAll('#rows tr').forEach(function(row) {{
+      const text = row.textContent.toLowerCase();
+      const matchesText = !q || text.includes(q);
+      const matchesStatus = !status || row.dataset.status === status;
+      const matchesCompany = !company || row.dataset.company === company;
+      row.style.display = (matchesText && matchesStatus && matchesCompany) ? '' : 'none';
+    }});
+  }}
+  search.addEventListener('input', apply);
+  statusFilter.addEventListener('change', apply);
+  companyFilter.addEventListener('change', apply);
+}})();
+</script>
+</body>
+</html>
+"""
+
+
+def build_report(db_path: str, output_path: str) -> dict:
+    """Generate the dashboard HTML and write it to output_path. Returns stats."""
+    rows = fetch_rows(db_path)
+    stats = compute_stats(rows)
+    html = render_html(rows, stats)
+
+    out_dir = os.path.dirname(os.path.abspath(output_path))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    return stats

--- a/swelist/tracker.py
+++ b/swelist/tracker.py
@@ -3,11 +3,14 @@ import io
 import json
 import os
 import sqlite3
+import webbrowser
 from typing import Optional
 
 import typer
 from rich import print
 from rich.table import Table
+
+from swelist.report import build_report
 
 tracker_app = typer.Typer(help="Local SQLite job application tracker")
 
@@ -197,3 +200,32 @@ def tracker_export(
         writer.writeheader()
         writer.writerows([dict(r) for r in rows])
         print(buf.getvalue(), end="")
+
+
+@tracker_app.command("report")
+def tracker_report(
+    output: str = typer.Argument("reports/application-dashboard.html", help="Output path for the HTML dashboard"),
+    db: str = typer.Option(DEFAULT_DB, help="Path to SQLite database"),
+    open_browser: bool = typer.Option(False, "--open", help="Open the dashboard in your default browser"),
+):
+    """Generate a self-contained HTML dashboard from the tracker database."""
+    if not os.path.exists(db):
+        print(f"[red]No tracker database found at {db}. Run 'swelist tracker init' first.[/red]")
+        raise typer.Exit(1)
+
+    stats = build_report(db, output)
+
+    print(f"[green]Dashboard generated:[/green] {output}")
+    if stats["total"] == 0:
+        print("[yellow]No applications tracked yet.[/yellow]")
+    else:
+        buckets = stats["by_bucket"]
+        print(
+            f"Total: {stats['total']} · Active: {buckets.get('Active', 0)} · "
+            f"Interview: {buckets.get('Interview', 0)} · Offer: {buckets.get('Offer', 0)} · "
+            f"Hired: {buckets.get('Hired', 0)} · Rejected/Closed: {buckets.get('Rejected/Closed', 0)}"
+        )
+        print(f"Funnel: {stats['funnel_pct']}% progressed past resume screen")
+
+    if open_browser:
+        webbrowser.open(f"file://{os.path.abspath(output)}")

--- a/tests/test_html_report_skill.py
+++ b/tests/test_html_report_skill.py
@@ -1,0 +1,79 @@
+"""Structural tests for the html-report skill (skills/html-report/SKILL.md).
+
+Mirrors the pattern used for other reference-driven skills in this repo:
+plain assertions against the real files, catching the kind of drift CI
+would otherwise miss (missing required sections, stale references to the
+old CSV-based design, a generated-report path that isn't gitignored).
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_FILE = REPO_ROOT / "skills" / "html-report" / "SKILL.md"
+GITIGNORE = REPO_ROOT / ".gitignore"
+PROFILE = REPO_ROOT / "skills" / "profile.md"
+
+# CLAUDE.md's "Writing a new skill" section requires these sections, in order.
+REQUIRED_SECTIONS = [
+    "## When to Use This Skill",
+    "## Setup",
+    "## Config:",
+    "## Workflow",
+    "## Report Format",
+    "## Edge Cases",
+]
+
+
+def _skill_text():
+    return SKILL_FILE.read_text(encoding="utf-8")
+
+
+def test_skill_file_exists():
+    assert SKILL_FILE.exists(), f"{SKILL_FILE} not found"
+
+
+def test_skill_frontmatter_has_name_and_description():
+    text = _skill_text()
+    assert text.startswith("---\n"), "SKILL.md must start with a YAML frontmatter block"
+    frontmatter = text.split("---", 2)[1]
+    assert "name:" in frontmatter
+    assert "description:" in frontmatter
+
+
+def test_skill_file_is_non_trivial():
+    text = _skill_text().strip()
+    assert len(text) > 2000, "SKILL.md appears suspiciously short"
+
+
+def test_skill_contains_required_sections():
+    text = _skill_text()
+    for section in REQUIRED_SECTIONS:
+        assert section in text, f"Missing required section: {section!r}"
+
+
+def test_skill_reads_the_shared_sqlite_tracker():
+    text = _skill_text()
+    assert "~/.offerplus/applications.db" in text
+    assert "job-application-manager" in text
+    assert "sqlite" in text.lower()
+
+
+def test_skill_no_longer_references_the_old_csv_design():
+    text = _skill_text()
+    assert "job_search_tracker.csv" not in text
+    assert "documents/applications" not in text
+
+
+def test_skill_is_documented_as_read_only():
+    text = _skill_text()
+    assert "read-only" in text.lower()
+
+
+def test_reports_folder_is_gitignored():
+    rules = {line.strip() for line in GITIGNORE.read_text(encoding="utf-8").splitlines()}
+    assert "reports/" in rules, "reports/ must be gitignored — generated dashboards are personal output"
+
+
+def test_profile_lists_html_report_skill():
+    text = PROFILE.read_text(encoding="utf-8")
+    assert "`html-report`" in text

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,176 @@
+import sqlite3
+
+import pytest
+
+from swelist.report import build_report, compute_stats, fetch_rows, render_html
+from swelist.tracker import INIT_SQL
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = str(tmp_path / "applications.db")
+    conn = sqlite3.connect(path)
+    conn.execute(INIT_SQL)
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def populated_db(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO applications (name, status, job_id, applied_on, notes) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("Amazon — SDE, AWS", "In progress", "10414382", "2026-05-17", "great team"),
+            ("Google — Software Engineer", "Rejected", "G123", "2026-04-01", None),
+            ("Meta — SWE, Infra", "Done", "M456", "2026-03-15", None),
+            ("Stripe — Backend Engineer", "Not started", None, None, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def full_schema_db(tmp_path):
+    """A DB using the richer v0.5.0 schema (company, tags, next_action, etc.)."""
+    path = str(tmp_path / "full.db")
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE applications (
+            name TEXT PRIMARY KEY, status TEXT NOT NULL, job_id TEXT, company TEXT,
+            applied_on TEXT, last_touch TEXT, interview_date TEXT, next_action TEXT,
+            link TEXT, tags TEXT, notes TEXT, updated_at TEXT DEFAULT (datetime('now'))
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO applications (name, status, company, applied_on, interview_date, "
+        "next_action, link, tags, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Anthropic — SWE",
+            "Interviewing",
+            "Anthropic",
+            "2026-06-01",
+            "2026-06-09",
+            "Prep",
+            "https://boards.greenhouse.io/anthropic/jobs/1",
+            "Referral,Remote",
+            "Recruiter call went well",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+class TestFetchRows:
+    def test_fetch_rows_count_and_bucket_mapping(self, populated_db):
+        rows = fetch_rows(populated_db)
+        assert len(rows) == 4
+        buckets = {r["name"]: r["bucket"] for r in rows}
+        assert buckets["Amazon — SDE, AWS"] == "Interview"  # In progress
+        assert buckets["Google — Software Engineer"] == "Rejected/Closed"
+        assert buckets["Meta — SWE, Infra"] == "Hired"  # Done
+        assert buckets["Stripe — Backend Engineer"] == "Active"  # Not started
+
+    def test_fetch_rows_splits_company_and_role(self, populated_db):
+        rows = fetch_rows(populated_db)
+        amazon = next(r for r in rows if r["name"] == "Amazon — SDE, AWS")
+        assert amazon["company_display"] == "Amazon"
+        assert amazon["role_display"] == "SDE, AWS"
+
+    def test_fetch_rows_falls_back_on_base_schema(self, populated_db):
+        rows = fetch_rows(populated_db)
+        # v0.2.x schema has no tags/company/etc columns — should not error
+        assert all(r["tag_list"] == [] for r in rows)
+        assert all(r.get("link") is None for r in rows)
+
+    def test_fetch_rows_uses_full_schema_columns(self, full_schema_db):
+        rows = fetch_rows(full_schema_db)
+        row = rows[0]
+        assert row["company_display"] == "Anthropic"
+        assert row["tag_list"] == ["Referral", "Remote"]
+        assert row["link"] == "https://boards.greenhouse.io/anthropic/jobs/1"
+        assert row["bucket"] == "Interview"
+
+
+class TestComputeStats:
+    def test_totals_and_buckets(self, populated_db):
+        stats = compute_stats(fetch_rows(populated_db))
+        assert stats["total"] == 4
+        assert stats["by_bucket"]["Interview"] == 1
+        assert stats["by_bucket"]["Hired"] == 1
+        assert stats["by_bucket"]["Rejected/Closed"] == 1
+        assert stats["by_bucket"]["Active"] == 1
+
+    def test_funnel_and_rejection_rate(self, populated_db):
+        stats = compute_stats(fetch_rows(populated_db))
+        # Interview + Hired = 2 of 4 total progressed past screen
+        assert stats["funnel_pct"] == 50
+        # 3 resolved (non-Active): 1 rejected / 3 resolved = 33%
+        assert stats["rejection_pct"] == 33
+
+    def test_empty_rows(self):
+        stats = compute_stats([])
+        assert stats["total"] == 0
+        assert stats["funnel_pct"] == 0
+        assert stats["rejection_pct"] == 0
+
+    def test_by_tag_from_full_schema(self, full_schema_db):
+        stats = compute_stats(fetch_rows(full_schema_db))
+        assert stats["by_tag"]["Referral"] == 1
+        assert stats["by_tag"]["Remote"] == 1
+
+    def test_unmapped_status_is_flagged(self, db_path):
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "INSERT INTO applications (name, status) VALUES (?, ?)",
+            ("Weird — Co", "Some Unknown Status"),
+        )
+        conn.commit()
+        conn.close()
+        stats = compute_stats(fetch_rows(db_path))
+        assert "Some Unknown Status" in stats["unmapped_statuses"]
+        # unmapped statuses still fall back to Active rather than being dropped
+        assert stats["by_bucket"]["Active"] == 1
+
+
+class TestRenderHtml:
+    def test_render_html_basic_structure(self, populated_db):
+        rows = fetch_rows(populated_db)
+        stats = compute_stats(rows)
+        html = render_html(rows, stats)
+        assert html.startswith("<!doctype html>")
+        assert "cdn.jsdelivr.net/npm/chart.js" in html
+        assert html.count('<tr data-status') == 4
+        assert "Amazon" in html
+        assert "—" in html  # em dash preserved, not mangled
+
+    def test_render_html_empty_state(self):
+        html = render_html([], compute_stats([]))
+        assert "No applications tracked yet" in html
+        assert '<tr data-status' not in html
+
+    def test_render_html_link_only_rendered_when_http(self, full_schema_db):
+        rows = fetch_rows(full_schema_db)
+        html = render_html(rows, compute_stats(rows))
+        assert '<a href="https://boards.greenhouse.io/anthropic/jobs/1"' in html
+
+
+class TestBuildReport:
+    def test_writes_file_and_returns_stats(self, populated_db, tmp_path):
+        output = str(tmp_path / "out" / "dashboard.html")
+        stats = build_report(populated_db, output)
+        assert stats["total"] == 4
+        with open(output, encoding="utf-8") as f:
+            content = f.read()
+        assert content.startswith("<!doctype html>")
+
+    def test_creates_parent_directory(self, populated_db, tmp_path):
+        output = str(tmp_path / "nested" / "dir" / "dashboard.html")
+        build_report(populated_db, output)
+        assert (tmp_path / "nested" / "dir" / "dashboard.html").exists()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -227,3 +227,54 @@ class TestTrackerExport:
         assert row["status"] == "In progress"
         assert row["job_id"] == "10414382"
         assert row["applied_on"] == "2026-05-17"
+
+
+class TestTrackerReport:
+    def test_report_writes_html_file(self, populated_db, tmp_path):
+        output = str(tmp_path / "dashboard.html")
+        result = runner.invoke(tracker_app, ["report", output, "--db", populated_db])
+        assert result.exit_code == 0
+        assert "Dashboard generated" in result.output
+        assert os.path.exists(output)
+        with open(output, encoding="utf-8") as f:
+            assert f.read().startswith("<!doctype html>")
+
+    def test_report_prints_bucket_summary(self, populated_db, tmp_path):
+        output = str(tmp_path / "dashboard.html")
+        result = runner.invoke(tracker_app, ["report", output, "--db", populated_db])
+        assert "Total: 4" in result.output
+        assert "Funnel:" in result.output
+
+    def test_report_default_output_path(self, populated_db, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(tracker_app, ["report", "--db", populated_db])
+        assert result.exit_code == 0
+        assert os.path.exists(tmp_path / "reports" / "application-dashboard.html")
+
+    def test_report_empty_db(self, db_path, tmp_path):
+        output = str(tmp_path / "dashboard.html")
+        result = runner.invoke(tracker_app, ["report", output, "--db", db_path])
+        assert result.exit_code == 0
+        assert "No applications tracked yet" in result.output
+
+    def test_report_missing_db(self, tmp_path):
+        missing = str(tmp_path / "does-not-exist.db")
+        output = str(tmp_path / "dashboard.html")
+        result = runner.invoke(tracker_app, ["report", output, "--db", missing])
+        assert result.exit_code == 1
+        assert "No tracker database found" in result.output
+        assert not os.path.exists(output)
+
+    def test_report_open_flag_launches_browser(self, populated_db, tmp_path, mocker):
+        output = str(tmp_path / "dashboard.html")
+        mock_open = mocker.patch("swelist.tracker.webbrowser.open")
+        result = runner.invoke(tracker_app, ["report", output, "--db", populated_db, "--open"])
+        assert result.exit_code == 0
+        mock_open.assert_called_once()
+        assert output in mock_open.call_args[0][0]
+
+    def test_report_without_open_flag_does_not_launch_browser(self, populated_db, tmp_path, mocker):
+        output = str(tmp_path / "dashboard.html")
+        mock_open = mocker.patch("swelist.tracker.webbrowser.open")
+        runner.invoke(tracker_app, ["report", output, "--db", populated_db])
+        mock_open.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds a `html-report` Claude Code skill (`skills/html-report/SKILL.md`) that generates a self-contained HTML dashboard (stat cards, Chart.js charts, filterable table) from the shared SQLite tracker database used by `job-application-manager`, and adds structural tests for it plus a `reports/` `.gitignore` entry.
- Adds a native `swelist tracker report [output] [--db PATH] [--open]` CLI command (`swelist/report.py`) that generates the same dashboard deterministically in Python, without Claude — reads the same `applications` table, adapts to either the base or richer tracker schema, and `--open` launches the browser directly.
- Updates `CLAUDE.md` (Quick Reference, Project Layout, CLI Architecture, Testing) and `skills/profile.md` to document the new command/skill.

## Test plan
- [x] `pytest` — full suite passes (67 passed, 6 skipped; skipped tests require the optional `openai` extra)
- [x] `pytest tests/test_report.py` — unit tests for the HTML generator (99% coverage on `report.py`)
- [x] `pytest tests/test_tracker.py` — CLI tests for `swelist tracker report`, including empty DB, missing DB, default output path, and `--open` browser launch (100% coverage on `tracker.py`)
- [x] `pytest tests/test_html_report_skill.py` — structural checks on the Claude skill file
- [x] `flake8` clean on all touched files
- [x] Manually generated a dashboard against a populated SQLite DB and inspected the output HTML (doctype, Chart.js CDN reference, correct stat-card counts, correct table row count)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VB6TWhE8mqzwCAQzAmk54x)_